### PR TITLE
Create a pixel based coordinate system that maps to 3D.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "dscale",
         "fovy",
         "Gustavson",
+        "hitbox",
         "multisampled",
         "multiview",
         "rsqrt",

--- a/geometry/src/bounds3.rs
+++ b/geometry/src/bounds3.rs
@@ -1,0 +1,18 @@
+use crate::{Point3, Size3};
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Bounds3 {
+    pub min: Point3,
+    pub max: Point3,
+}
+
+impl Bounds3 {
+    pub fn new(min: Point3, max: Point3) -> Self {
+        Self { min, max }
+    }
+
+    pub fn size(&self) -> Size3 {
+        let v = self.max - self.min;
+        Size3::new((v.x, v.y, v.z).into())
+    }
+}

--- a/geometry/src/lib.rs
+++ b/geometry/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod bezier_algorithms;
 mod bounds;
+mod bounds3;
 mod camera;
 mod color;
 mod cubic_bezier;
@@ -11,9 +12,11 @@ mod point;
 mod projection;
 mod rect;
 mod size;
+mod size3;
 mod unit_interval;
 
 pub use bounds::*;
+pub use bounds3::*;
 pub use camera::*;
 pub use color::*;
 pub use cubic_bezier::*;
@@ -21,7 +24,8 @@ pub use line::*;
 pub use point::*;
 pub use projection::*;
 pub use rect::*;
-pub use size::Size;
+pub use size::*;
+pub use size3::*;
 pub use unit_interval::*;
 
 #[allow(non_camel_case_types)]
@@ -46,6 +50,7 @@ pub fn view_projection_matrix(camera: &Camera, projection: &Projection) -> Matri
 }
 
 // TODO: this is WGPU specific.
+// <https://sotrh.github.io/learn-wgpu/intermediate/tutorial12-camera/#the-camera>
 #[rustfmt::skip]
 pub const OPENGL_TO_WGPU_MATRIX: Matrix4 = Matrix4::new(
     1.0, 0.0, 0.0, 0.0,

--- a/geometry/src/size.rs
+++ b/geometry/src/size.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Sub};
+use std::ops;
 
 use crate::Point;
 
@@ -20,7 +20,15 @@ impl From<(f64, f64)> for Size {
     }
 }
 
-impl Div<f64> for Size {
+impl ops::Mul<f64> for Size {
+    type Output = Size;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self::new(self.width * rhs, self.height * rhs)
+    }
+}
+
+impl ops::Div<f64> for Size {
     type Output = Size;
 
     fn div(self, rhs: f64) -> Self::Output {
@@ -28,18 +36,18 @@ impl Div<f64> for Size {
     }
 }
 
-impl Sub<Size> for Point {
-    type Output = Point;
-
-    fn sub(self, rhs: Size) -> Self::Output {
-        Point::new(self.x - rhs.width, self.y - rhs.height)
-    }
-}
-
-impl Add<Size> for Point {
+impl ops::Add<Size> for Point {
     type Output = Point;
 
     fn add(self, rhs: Size) -> Self::Output {
         Point::new(self.x + rhs.width, self.y + rhs.height)
+    }
+}
+
+impl ops::Sub<Size> for Point {
+    type Output = Point;
+
+    fn sub(self, rhs: Size) -> Self::Output {
+        Point::new(self.x - rhs.width, self.y - rhs.height)
     }
 }

--- a/geometry/src/size3.rs
+++ b/geometry/src/size3.rs
@@ -1,0 +1,78 @@
+use std::ops;
+
+use crate::{Point3, Vector3};
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Size3(Vector3);
+
+impl Size3 {
+    pub const fn new(v: Vector3) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Vector3> for Size3 {
+    fn from(v: Vector3) -> Self {
+        Self::new(v)
+    }
+}
+
+impl From<(f64, f64, f64)> for Size3 {
+    fn from((x, y, z): (f64, f64, f64)) -> Self {
+        Self::new((x, y, z).into())
+    }
+}
+
+impl ops::Mul<f64> for Size3 {
+    type Output = Size3;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self::new(self.0 * rhs)
+    }
+}
+
+impl ops::Div<f64> for Size3 {
+    type Output = Size3;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        Self::new(self.0 / rhs)
+    }
+}
+
+impl ops::Add<Size3> for Size3 {
+    type Output = Size3;
+
+    fn add(self, rhs: Size3) -> Self::Output {
+        Self::new(self.0 + rhs.0)
+    }
+}
+
+impl ops::Sub<Size3> for Size3 {
+    type Output = Size3;
+
+    fn sub(self, rhs: Size3) -> Self::Output {
+        Self::new(self.0 - rhs.0)
+    }
+}
+
+impl ops::Add<Size3> for Point3 {
+    type Output = Self;
+
+    fn add(self, rhs: Size3) -> Self::Output {
+        self + rhs.0
+    }
+}
+
+impl ops::Sub<Size3> for Point3 {
+    type Output = Self;
+
+    fn sub(self, rhs: Size3) -> Self::Output {
+        self - rhs.0
+    }
+}
+
+impl From<Size3> for Vector3 {
+    fn from(size: Size3) -> Self {
+        size.0
+    }
+}

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -154,6 +154,10 @@ impl Shell {
 
         Ok(())
     }
+
+    fn runtime(&self) -> granularity::Runtime {
+        self.font_system.runtime()
+    }
 }
 
 pub fn time<T>(name: &str, f: impl FnOnce() -> T) -> T {

--- a/text/src/label.rs
+++ b/text/src/label.rs
@@ -9,10 +9,24 @@ use wgpu::{util::DeviceExt, TextureView};
 use crate::TextureVertex;
 
 pub struct Label {
-    pub placed_glyphs: Value<Vec<PlacedGlyph>>,
+    placed_glyphs: Value<(LabelMetrics, Vec<PlacedGlyph>)>,
+    pub metrics: Value<LabelMetrics>,
     /// TODO: Separate?
     pub placements_and_texture_views: Value<Vec<Option<(text::Placement, TextureView)>>>,
     pub vertex_buffers: Value<Vec<Option<wgpu::Buffer>>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LabelMetrics {
+    pub ascent: u32,
+    pub descent: u32,
+    pub width: u32,
+}
+
+impl LabelMetrics {
+    pub fn size(&self) -> (u32, u32) {
+        (self.width, self.ascent + self.descent)
+    }
 }
 
 pub fn new_label(shell: &Shell, font_size: Value<f32>, text: Value<String>) -> Label {
@@ -34,9 +48,19 @@ pub fn new_label(shell: &Shell, font_size: Value<f32>, text: Value<String>) -> L
             text::AttrsList::new(text::Attrs::new()),
             text::Shaping::Advanced,
         );
-        let line = &buffer.layout(font_system, *font_size, f32::MAX, text::Wrap::None)[0].glyphs;
-        place_glyphs(line)
+        let line = &buffer.layout(font_system, *font_size, f32::MAX, text::Wrap::None)[0];
+        let line_glyphs = &line.glyphs;
+        let placed = place_glyphs(line_glyphs);
+        println!("placed: {:?}", placed);
+        let metrics = LabelMetrics {
+            ascent: line.max_ascent as u32,
+            descent: line.max_descent as u32,
+            width: line.w.ceil() as u32,
+        };
+        (metrics, placed)
     });
+
+    let metrics = map_ref!(|placed_glyphs| placed_glyphs.0);
 
     // For now they have to be combined because we only receive placements and the imagines together
     // from the SwashCache, and the images are only accessible by reference.
@@ -47,6 +71,7 @@ pub fn new_label(shell: &Shell, font_size: Value<f32>, text: Value<String>) -> L
             let mut glyph_cache = glyph_cache.borrow_mut();
             let glyph_cache = glyph_cache.deref_mut();
             placed_glyphs
+                .1
                 .iter()
                 .map(|placed_glyph| {
                     let image = glyph_cache
@@ -70,7 +95,7 @@ pub fn new_label(shell: &Shell, font_size: Value<f32>, text: Value<String>) -> L
                 .enumerate()
                 .map(|(i, placement_and_view)| {
                     placement_and_view.as_ref().map(|(placement, _)| {
-                        let rect = place_glyph(placed_glyphs[i].pos, *placement);
+                        let rect = place_glyph(placed_glyphs.1[i].hitbox_pos, *placement);
 
                         let vertices = glyph_to_texture_vertex(
                             surface_config,
@@ -90,19 +115,26 @@ pub fn new_label(shell: &Shell, font_size: Value<f32>, text: Value<String>) -> L
 
     Label {
         placed_glyphs,
+        metrics,
         placements_and_texture_views,
         vertex_buffers,
     }
 }
 
+#[derive(Debug)]
 pub struct PlacedGlyph {
     pub cache_key: text::CacheKey,
-    pub pos: (i32, i32),
+    pub hitbox_pos: (i32, i32),
+    pub hitbox_width: f32,
 }
 
 impl PlacedGlyph {
-    fn new(cache_key: text::CacheKey, pos: (i32, i32)) -> Self {
-        Self { cache_key, pos }
+    fn new(cache_key: text::CacheKey, hitbox_pos: (i32, i32), hitbox_width: f32) -> Self {
+        Self {
+            cache_key,
+            hitbox_pos,
+            hitbox_width,
+        }
     }
 }
 
@@ -118,14 +150,15 @@ fn place_glyphs(glyphs: &[text::LayoutGlyph]) -> Vec<PlacedGlyph> {
                 (glyph.x.round(), glyph.y.round())
             };
 
-            // TODO: disable Subpixel rendering?
             let (cc, x, y) = text::CacheKey::new(
                 glyph.font_id,
                 glyph.glyph_id,
                 glyph.font_size,
                 fractional_pos,
             );
-            PlacedGlyph::new(cc, (x, y))
+            // Note: hitbox with is fractional, but does not change with / without subpixel
+            // rendering.
+            PlacedGlyph::new(cc, (x, y), glyph.w)
         })
         .collect()
 }
@@ -175,14 +208,14 @@ fn image_to_texture(
 }
 
 // Until vertex conversion, coordinate system is ((0,0), (surface.width,surface.height))
-const BASELINE_Y: i32 = 200;
+const BASELINE_Y: i32 = 0;
 
 // TODO: need a rect structure.
 
-fn place_glyph(pos: (i32, i32), placement: text::Placement) -> (Point2<i32>, Point2<i32>) {
-    let left = pos.0 + placement.left;
+fn place_glyph(hitbox_pos: (i32, i32), placement: text::Placement) -> (Point2<i32>, Point2<i32>) {
+    let left = hitbox_pos.0 + placement.left;
     // placement goes up (right handed coordinate system).
-    let top = pos.1 + BASELINE_Y - placement.top;
+    let top = hitbox_pos.1 + BASELINE_Y - placement.top;
     let right = left + placement.width as i32;
     let bottom = top + placement.height as i32;
 
@@ -194,10 +227,10 @@ fn glyph_to_texture_vertex(
     rect: (Point2<f32>, Point2<f32>),
 ) -> [TextureVertex; 4] {
     // TODO: use a 2D matrix here?
-    let left = rect.0.x / surface_config.height as f32 * 2.0 - 1.0;
-    let top = (rect.0.y / surface_config.height as f32 * 2.0 - 1.0) * -1.0;
-    let right = rect.1.x / surface_config.height as f32 * 2.0 - 1.0;
-    let bottom = (rect.1.y / surface_config.height as f32 * 2.0 - 1.0) * -1.0;
+    let left = rect.0.x / surface_config.height as f32 * 2.0;
+    let top = (rect.0.y / surface_config.height as f32 * 2.0) * -1.0;
+    let right = rect.1.x / surface_config.height as f32 * 2.0;
+    let bottom = (rect.1.y / surface_config.height as f32 * 2.0) * -1.0;
 
     [
         TextureVertex {

--- a/text/src/label.rs
+++ b/text/src/label.rs
@@ -4,7 +4,7 @@ use cgmath::Point2;
 use cosmic_text as text;
 use granularity::{map_ref, Value};
 use granularity_shell::Shell;
-use wgpu::{util::DeviceExt, TextureView};
+use wgpu::util::DeviceExt;
 
 use crate::TextureVertex;
 
@@ -12,7 +12,7 @@ pub struct Label {
     placed_glyphs: Value<(LabelMetrics, Vec<PlacedGlyph>)>,
     pub metrics: Value<LabelMetrics>,
     /// TODO: Separate?
-    pub placements_and_texture_views: Value<Vec<Option<(text::Placement, TextureView)>>>,
+    pub placements_and_texture_views: Value<Vec<Option<(text::Placement, wgpu::TextureView)>>>,
     pub vertex_buffers: Value<Vec<Option<wgpu::Buffer>>>,
 }
 
@@ -226,7 +226,7 @@ fn glyph_to_texture_vertex(
     surface_config: &wgpu::SurfaceConfiguration,
     rect: (Point2<f32>, Point2<f32>),
 ) -> [TextureVertex; 4] {
-    // TODO: use a 2D matrix here?
+    // TODO: use a 2D / 3D matrix here?
     let left = rect.0.x / surface_config.height as f32 * 2.0;
     let top = (rect.0.y / surface_config.height as f32 * 2.0) * -1.0;
     let right = rect.1.x / surface_config.height as f32 * 2.0;

--- a/text/src/label.rs
+++ b/text/src/label.rs
@@ -1,0 +1,220 @@
+use std::ops::DerefMut;
+
+use cgmath::Point2;
+use cosmic_text as text;
+use granularity::{map_ref, Value};
+use granularity_shell::Shell;
+use wgpu::{util::DeviceExt, TextureView};
+
+use crate::TextureVertex;
+
+pub struct Label {
+    pub placed_glyphs: Value<Vec<PlacedGlyph>>,
+    /// TODO: Separate?
+    pub placements_and_texture_views: Value<Vec<Option<(text::Placement, TextureView)>>>,
+    pub vertex_buffers: Value<Vec<Option<wgpu::Buffer>>>,
+}
+
+pub fn new_label(shell: &Shell, font_size: Value<f32>, text: Value<String>) -> Label {
+    let device = &shell.device;
+    let queue = &shell.queue;
+    let font_system = &shell.font_system;
+    let glyph_cache = &shell.glyph_cache;
+    let surface_config = &shell.surface_config;
+
+    let placed_glyphs = map_ref!(|font_system, text, font_size| {
+        let mut font_system = font_system.borrow_mut();
+        let font_system = font_system.deref_mut();
+        // TODO: Cosmic text recommends to use a single buffer for a widget, but we are creating a
+        // new one every time the text change. Not sure if that makes a big difference, because it
+        // seems that all the shaping information is being destroyed and only the buffer's memory
+        // is preserved.
+        let mut buffer = text::BufferLine::new(
+            text,
+            text::AttrsList::new(text::Attrs::new()),
+            text::Shaping::Advanced,
+        );
+        let line = &buffer.layout(font_system, *font_size, f32::MAX, text::Wrap::None)[0].glyphs;
+        place_glyphs(line)
+    });
+
+    // For now they have to be combined because we only receive placements and the imagines together
+    // from the SwashCache, and the images are only accessible by reference.
+    // TODO: Find a way to separate them.
+    let placements_and_texture_views =
+        map_ref!(|device, queue, font_system, glyph_cache, placed_glyphs| {
+            let mut font_system = font_system.borrow_mut();
+            let mut glyph_cache = glyph_cache.borrow_mut();
+            let glyph_cache = glyph_cache.deref_mut();
+            placed_glyphs
+                .iter()
+                .map(|placed_glyph| {
+                    let image = glyph_cache
+                        .get_image(&mut font_system, placed_glyph.cache_key)
+                        .as_ref();
+
+                    image
+                        .and_then(|image| {
+                            (image.placement.width != 0 && image.placement.height != 0)
+                                .then_some(image)
+                        })
+                        .map(|image| (image.placement, image_to_texture(device, queue, image)))
+                })
+                .collect::<Vec<_>>()
+        });
+
+    let vertex_buffers = map_ref!(
+        |device, surface_config, placed_glyphs, placements_and_texture_views| {
+            placements_and_texture_views
+                .iter()
+                .enumerate()
+                .map(|(i, placement_and_view)| {
+                    placement_and_view.as_ref().map(|(placement, _)| {
+                        let rect = place_glyph(placed_glyphs[i].pos, *placement);
+
+                        let vertices = glyph_to_texture_vertex(
+                            surface_config,
+                            (rect.0.cast().unwrap(), rect.1.cast().unwrap()),
+                        );
+
+                        device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                            label: Some("Vertex Buffer"),
+                            contents: bytemuck::cast_slice(&vertices),
+                            usage: wgpu::BufferUsages::VERTEX,
+                        })
+                    })
+                })
+                .collect::<Vec<_>>()
+        }
+    );
+
+    Label {
+        placed_glyphs,
+        placements_and_texture_views,
+        vertex_buffers,
+    }
+}
+
+pub struct PlacedGlyph {
+    pub cache_key: text::CacheKey,
+    pub pos: (i32, i32),
+}
+
+impl PlacedGlyph {
+    fn new(cache_key: text::CacheKey, pos: (i32, i32)) -> Self {
+        Self { cache_key, pos }
+    }
+}
+
+const RENDER_SUBPIXEL: bool = false;
+
+fn place_glyphs(glyphs: &[text::LayoutGlyph]) -> Vec<PlacedGlyph> {
+    glyphs
+        .iter()
+        .map(|glyph| {
+            let fractional_pos = if RENDER_SUBPIXEL {
+                (glyph.x, glyph.y)
+            } else {
+                (glyph.x.round(), glyph.y.round())
+            };
+
+            // TODO: disable Subpixel rendering?
+            let (cc, x, y) = text::CacheKey::new(
+                glyph.font_id,
+                glyph.glyph_id,
+                glyph.font_size,
+                fractional_pos,
+            );
+            PlacedGlyph::new(cc, (x, y))
+        })
+        .collect()
+}
+
+/// Creates an empty texture and queues it for uploading to the GPU.
+fn image_to_texture(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    image: &text::SwashImage,
+) -> wgpu::TextureView {
+    let texture_size = wgpu::Extent3d {
+        width: image.placement.width,
+        height: image.placement.height,
+        depth_or_array_layers: 1,
+    };
+
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: texture_size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::R8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        label: Some("Character Texture"),
+        view_formats: &[],
+    });
+
+    // TODO: how to separate this from texture creation?
+    queue.write_texture(
+        wgpu::ImageCopyTexture {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        &image.data,
+        wgpu::ImageDataLayout {
+            offset: 0,
+            bytes_per_row: Some(image.placement.width),
+            // TODO: this looks optional.
+            rows_per_image: Some(image.placement.height),
+        },
+        texture_size,
+    );
+
+    texture.create_view(&wgpu::TextureViewDescriptor::default())
+}
+
+// Until vertex conversion, coordinate system is ((0,0), (surface.width,surface.height))
+const BASELINE_Y: i32 = 200;
+
+// TODO: need a rect structure.
+
+fn place_glyph(pos: (i32, i32), placement: text::Placement) -> (Point2<i32>, Point2<i32>) {
+    let left = pos.0 + placement.left;
+    // placement goes up (right handed coordinate system).
+    let top = pos.1 + BASELINE_Y - placement.top;
+    let right = left + placement.width as i32;
+    let bottom = top + placement.height as i32;
+
+    ((left, top).into(), (right, bottom).into())
+}
+
+fn glyph_to_texture_vertex(
+    surface_config: &wgpu::SurfaceConfiguration,
+    rect: (Point2<f32>, Point2<f32>),
+) -> [TextureVertex; 4] {
+    // TODO: use a 2D matrix here?
+    let left = rect.0.x / surface_config.height as f32 * 2.0 - 1.0;
+    let top = (rect.0.y / surface_config.height as f32 * 2.0 - 1.0) * -1.0;
+    let right = rect.1.x / surface_config.height as f32 * 2.0 - 1.0;
+    let bottom = (rect.1.y / surface_config.height as f32 * 2.0 - 1.0) * -1.0;
+
+    [
+        TextureVertex {
+            position: (left, top, 0.0).into(),
+            tex_coords: [0.0, 0.0],
+        },
+        TextureVertex {
+            position: (left, bottom, 0.0).into(),
+            tex_coords: [0.0, 1.0],
+        },
+        TextureVertex {
+            position: (right, bottom, 0.0).into(),
+            tex_coords: [1.0, 1.0],
+        },
+        TextureVertex {
+            position: (right, top, 0.0).into(),
+            tex_coords: [1.0, 0.0],
+        },
+    ]
+}

--- a/text/src/layout.rs
+++ b/text/src/layout.rs
@@ -1,0 +1,26 @@
+use cgmath::EuclideanSpace;
+use granularity::{map_ref, Value};
+use granularity_geometry::{Bounds3, Matrix4, Point3, Size3, Vector3};
+
+pub trait Extent {
+    /// The size of the object.
+    fn size(&self) -> Size3;
+
+    /// The baseline of the object in layout direction, if any.
+    ///
+    /// Also the `ascent` of the object. Always positive. Describes the distance of the baseline from the top of the extent.
+    fn baseline(&self) -> Option<f64> {
+        None
+    }
+}
+
+pub fn center<E: Extent>(container: Value<Bounds3>, inner: Value<E>) -> Value<Matrix4> {
+    map_ref!(|container, inner| {
+        let container_size = container.size();
+        let inner_size = inner.size();
+        let container_center = container.min + container_size / 2.0;
+        let inner_center: Point3 = Point3::origin() + Vector3::from(inner_size / 2.0);
+        let offset = container_center - inner_center;
+        Matrix4::from_translation(offset)
+    })
+}

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -1,9 +1,11 @@
 mod distance_field_gen;
 mod label;
+mod layout;
 mod point;
 mod render_graph;
 mod vertex;
 
 pub use label::*;
+pub use layout::*;
 pub use render_graph::render_graph;
 pub use vertex::*;

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -1,5 +1,9 @@
 mod distance_field_gen;
+mod label;
 mod point;
 mod render_graph;
+mod vertex;
 
+pub use label::*;
 pub use render_graph::render_graph;
+pub use vertex::*;

--- a/text/src/render_graph.rs
+++ b/text/src/render_graph.rs
@@ -1,9 +1,3 @@
-use std::{mem, ops::DerefMut};
-
-use cgmath::Point2;
-use cosmic_text::{self as text, SwashImage};
-use granularity_shell::Shell;
-use log::debug;
 use swash::{
     scale::{image::Image, Render, ScaleContext, Source, StrikeWith},
     zeno::Format,
@@ -13,54 +7,18 @@ use wgpu::util::DeviceExt;
 
 use granularity::{map_ref, Value};
 use granularity_geometry::{scalar, view_projection_matrix, Camera, Projection};
+use granularity_shell::Shell;
 
-struct PlacedGlyph {
-    cache_key: text::CacheKey,
-    pos: (i32, i32),
-}
-
-impl PlacedGlyph {
-    fn new(cache_key: text::CacheKey, pos: (i32, i32)) -> Self {
-        Self { cache_key, pos }
-    }
-}
-
-const RENDER_SUBPIXEL: bool = false;
-
-fn place_glyphs(glyphs: &[text::LayoutGlyph]) -> Vec<PlacedGlyph> {
-    glyphs
-        .iter()
-        .map(|glyph| {
-            let fractional_pos = if RENDER_SUBPIXEL {
-                (glyph.x, glyph.y)
-            } else {
-                (glyph.x.round(), glyph.y.round())
-            };
-
-            // TODO: disable Subpixel rendering?
-            let (cc, x, y) = text::CacheKey::new(
-                glyph.font_id,
-                glyph.glyph_id,
-                glyph.font_size,
-                fractional_pos,
-            );
-            PlacedGlyph::new(cc, (x, y))
-        })
-        .collect()
-}
+use crate::{new_label, TextureVertex};
 
 pub fn render_graph(
     camera: Value<Camera>,
     text: Value<String>,
     shell: &Shell,
 ) -> (Value<wgpu::CommandBuffer>, Value<wgpu::SurfaceTexture>) {
-    let font_system = &shell.font_system;
-    let glyph_cache = &shell.glyph_cache;
     let device = &shell.device;
-    let queue = &shell.queue;
     let config = &shell.surface_config;
     let surface = &shell.surface;
-    let surface_config = &shell.surface_config;
 
     let shader = map_ref!(|device| {
         device.create_shader_module(wgpu::include_wgsl!("shaders/character-shader.wgsl"))
@@ -75,75 +33,9 @@ pub fn render_graph(
             .create_view(&wgpu::TextureViewDescriptor::default())
     });
 
-    let font_size = 28.0;
+    let font_size = shell.surface.runtime().var(28.0);
 
-    // Text
-
-    let placed_glyphs = map_ref!(|font_system, text| {
-        let mut font_system = font_system.borrow_mut();
-        let font_system = font_system.deref_mut();
-        // TODO: Cosmic text recommends to use a single buffer for a widget, but we are creating a
-        // new one every time the text change. Not sure if that makes a big difference, because it
-        // seems that all the shaping information is being destroyed and only the buffer's memory
-        // is preserved.
-        let mut buffer = text::BufferLine::new(
-            text,
-            text::AttrsList::new(text::Attrs::new()),
-            text::Shaping::Advanced,
-        );
-        let line = &buffer.layout(font_system, font_size, f32::MAX, text::Wrap::None)[0].glyphs;
-        place_glyphs(line)
-    });
-
-    // For now they have to be combined because we only receive placements and the imagines together
-    // from the SwashCache, and the images are only accessible by reference.
-    // TODO: Find a way to separate them.
-    let placements_and_texture_views =
-        map_ref!(|device, queue, font_system, glyph_cache, placed_glyphs| {
-            let mut font_system = font_system.borrow_mut();
-            let mut glyph_cache = glyph_cache.borrow_mut();
-            let glyph_cache = glyph_cache.deref_mut();
-            placed_glyphs
-                .iter()
-                .map(|placed_glyph| {
-                    let image = glyph_cache
-                        .get_image(&mut font_system, placed_glyph.cache_key)
-                        .as_ref();
-
-                    image
-                        .and_then(|image| {
-                            (image.placement.width != 0 && image.placement.height != 0)
-                                .then_some(image)
-                        })
-                        .map(|image| (image.placement, image_to_texture(device, queue, image)))
-                })
-                .collect::<Vec<_>>()
-        });
-
-    let vertex_buffers = map_ref!(
-        |device, surface_config, placed_glyphs, placements_and_texture_views| {
-            placements_and_texture_views
-                .iter()
-                .enumerate()
-                .map(|(i, placement_and_view)| {
-                    placement_and_view.as_ref().map(|(placement, _)| {
-                        let rect = place_glyph(placed_glyphs[i].pos, *placement);
-
-                        let vertices = glyph_to_texture_vertex(
-                            surface_config,
-                            (rect.0.cast().unwrap(), rect.1.cast().unwrap()),
-                        );
-
-                        device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                            label: Some("Vertex Buffer"),
-                            contents: bytemuck::cast_slice(&vertices),
-                            usage: wgpu::BufferUsages::VERTEX,
-                        })
-                    })
-                })
-                .collect::<Vec<_>>()
-        }
-    );
+    let label = new_label(shell, font_size, text);
 
     // Sample & Texture Bind Group
 
@@ -180,6 +72,8 @@ pub fn render_graph(
             ],
         })
     });
+
+    let placements_and_texture_views = &label.placements_and_texture_views;
 
     let texture_bind_groups = map_ref!(|device,
                                         texture_bind_group_layout,
@@ -324,6 +218,8 @@ pub fn render_graph(
         }
     ));
 
+    let vertex_buffers = &label.vertex_buffers;
+
     let command_buffer = map_ref!(|device,
                                    view,
                                    pipeline,
@@ -369,173 +265,8 @@ pub fn render_graph(
     (command_buffer, output)
 }
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-struct Vertex {
-    position: [f32; 3],
-}
-
-impl Vertex {
-    fn new(x: f32, y: f32, z: f32) -> Self {
-        Self {
-            position: [x, y, z],
-        }
-    }
-
-    fn desc() -> &'static wgpu::VertexBufferLayout<'static> {
-        const LAYOUT: wgpu::VertexBufferLayout = wgpu::VertexBufferLayout {
-            array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &wgpu::vertex_attr_array![0 => Float32x3],
-        };
-
-        &LAYOUT
-    }
-}
-
-impl From<(f32, f32, f32)> for Vertex {
-    fn from(v: (f32, f32, f32)) -> Self {
-        Self::new(v.0, v.1, v.2)
-    }
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-struct TextureVertex {
-    position: Vertex,
-    tex_coords: [f32; 2],
-}
-
-impl TextureVertex {
-    fn desc() -> &'static wgpu::VertexBufferLayout<'static> {
-        const LAYOUT: wgpu::VertexBufferLayout = wgpu::VertexBufferLayout {
-            array_stride: mem::size_of::<TextureVertex>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x2],
-        };
-
-        &LAYOUT
-    }
-}
-
 // We need this for Rust to store our data correctly for the shaders
 #[repr(C)]
 // This is so we can store this in a buffer
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct ViewProjectionUniform([[f32; 4]; 4]);
-
-// Render a character using swash.
-
-fn render_character(c: char) -> Image {
-    let mut context = ScaleContext::new();
-    let font = include_bytes!("fonts/Roboto-Regular.ttf");
-    let font = FontRef::from_index(font, 0).unwrap();
-
-    let scaler_builder = context.builder(font);
-    let mut scaler = scaler_builder.size(200.0).hint(false).build();
-
-    let glyph_id = font.charmap().map(c);
-
-    // We don't really care how the final image is rendered in detail, so we initialize a priority
-    // list of sources and let the renderer decide what to use.
-    let mut render = Render::new(&[
-        // Color outline with the first palette
-        Source::ColorOutline(0),
-        // Color bitmap with best fit selection mode
-        Source::ColorBitmap(StrikeWith::BestFit),
-        // Standard scalable outline
-        Source::Outline,
-    ]);
-    render.format(Format::Alpha).offset((0.0, 0.0).into());
-
-    render.render(&mut scaler, glyph_id).expect("image")
-}
-
-/// Creates an empty texture and queues it for uploading to the GPU.
-fn image_to_texture(
-    device: &wgpu::Device,
-    queue: &wgpu::Queue,
-    image: &SwashImage,
-) -> wgpu::TextureView {
-    let texture_size = wgpu::Extent3d {
-        width: image.placement.width,
-        height: image.placement.height,
-        depth_or_array_layers: 1,
-    };
-
-    let texture = device.create_texture(&wgpu::TextureDescriptor {
-        size: texture_size,
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::R8Unorm,
-        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-        label: Some("Character Texture"),
-        view_formats: &[],
-    });
-
-    // TODO: how to separate this from texture creation?
-    queue.write_texture(
-        wgpu::ImageCopyTexture {
-            texture: &texture,
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        },
-        &image.data,
-        wgpu::ImageDataLayout {
-            offset: 0,
-            bytes_per_row: Some(image.placement.width),
-            // TODO: this looks optional.
-            rows_per_image: Some(image.placement.height),
-        },
-        texture_size,
-    );
-
-    texture.create_view(&wgpu::TextureViewDescriptor::default())
-}
-
-// Until vertex conversion, coordinate system is ((0,0), (surface.width,surface.height))
-const BASELINE_Y: i32 = 200;
-
-// TODO: need a rect structure.
-
-fn place_glyph(pos: (i32, i32), placement: text::Placement) -> (Point2<i32>, Point2<i32>) {
-    let left = pos.0 + placement.left;
-    // placement goes up (right handed coordinate system).
-    let top = pos.1 + BASELINE_Y - placement.top;
-    let right = left + placement.width as i32;
-    let bottom = top + placement.height as i32;
-
-    ((left, top).into(), (right, bottom).into())
-}
-
-fn glyph_to_texture_vertex(
-    surface_config: &wgpu::SurfaceConfiguration,
-    rect: (Point2<f32>, Point2<f32>),
-) -> [TextureVertex; 4] {
-    // TODO: use a 2D matrix here?
-    let left = rect.0.x / surface_config.height as f32 * 2.0 - 1.0;
-    let top = (rect.0.y / surface_config.height as f32 * 2.0 - 1.0) * -1.0;
-    let right = rect.1.x / surface_config.height as f32 * 2.0 - 1.0;
-    let bottom = (rect.1.y / surface_config.height as f32 * 2.0 - 1.0) * -1.0;
-
-    [
-        TextureVertex {
-            position: (left, top, 0.0).into(),
-            tex_coords: [0.0, 0.0],
-        },
-        TextureVertex {
-            position: (left, bottom, 0.0).into(),
-            tex_coords: [0.0, 1.0],
-        },
-        TextureVertex {
-            position: (right, bottom, 0.0).into(),
-            tex_coords: [1.0, 1.0],
-        },
-        TextureVertex {
-            position: (right, top, 0.0).into(),
-            tex_coords: [1.0, 0.0],
-        },
-    ]
-}

--- a/text/src/render_graph.rs
+++ b/text/src/render_graph.rs
@@ -1,8 +1,3 @@
-use swash::{
-    scale::{image::Image, Render, ScaleContext, Source, StrikeWith},
-    zeno::Format,
-    FontRef,
-};
 use wgpu::util::DeviceExt;
 
 use granularity::{map_ref, Value};
@@ -42,8 +37,8 @@ pub fn render_graph(
     let texture_sampler = map_ref!(|device| device.create_sampler(&wgpu::SamplerDescriptor {
         address_mode_u: wgpu::AddressMode::ClampToEdge,
         address_mode_v: wgpu::AddressMode::ClampToEdge,
-        mag_filter: wgpu::FilterMode::Nearest,
-        min_filter: wgpu::FilterMode::Nearest,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
         ..Default::default()
     }));
 

--- a/text/src/shaders/character-shader.wgsl
+++ b/text/src/shaders/character-shader.wgsl
@@ -1,10 +1,9 @@
 // Vertex shader
 
-struct CameraUniform {
-    view_proj: mat4x4<f32>,
-};
 @group(1) @binding(0)
-var<uniform> camera: CameraUniform;
+var<uniform> camera: mat4x4<f32>;
+@group(2) @binding(0)
+var<uniform> model: mat4x4<f32>;
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
@@ -18,11 +17,11 @@ struct VertexOutput {
 
 @vertex
 fn vs_main(
-    model: VertexInput,
+    vertex_input: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coords = model.tex_coords;
-    out.clip_position = camera.view_proj * vec4<f32>(model.position, 1.0);
+    out.tex_coords = vertex_input.tex_coords;
+    out.clip_position = camera * model * vec4<f32>(vertex_input.position, 1.0);
     return out;
 }
 

--- a/text/src/vertex.rs
+++ b/text/src/vertex.rs
@@ -1,0 +1,52 @@
+//! TODO: This belongs to shell.
+
+use std::mem;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Vertex {
+    position: [f32; 3],
+}
+
+impl Vertex {
+    fn new(x: f32, y: f32, z: f32) -> Self {
+        Self {
+            position: [x, y, z],
+        }
+    }
+
+    fn desc() -> &'static wgpu::VertexBufferLayout<'static> {
+        const LAYOUT: wgpu::VertexBufferLayout = wgpu::VertexBufferLayout {
+            array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &wgpu::vertex_attr_array![0 => Float32x3],
+        };
+
+        &LAYOUT
+    }
+}
+
+impl From<(f32, f32, f32)> for Vertex {
+    fn from(v: (f32, f32, f32)) -> Self {
+        Self::new(v.0, v.1, v.2)
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct TextureVertex {
+    pub position: Vertex,
+    pub tex_coords: [f32; 2],
+}
+
+impl TextureVertex {
+    pub fn desc() -> &'static wgpu::VertexBufferLayout<'static> {
+        const LAYOUT: wgpu::VertexBufferLayout = wgpu::VertexBufferLayout {
+            array_stride: mem::size_of::<TextureVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x2],
+        };
+
+        &LAYOUT
+    }
+}


### PR DESCRIPTION
I think that placing widgets at pixels / points and layouting them is easier to do (and debug) compared to a -1.0 to 1.0 coordinate system the final surface uses.

Using pixels as the primary unit for specifying shapes and text also has the advantage that there is a basis for pixel snapping, text size, text shaping etc., which should lead to a better rendering quality.

In this PR I try to introduce a three dimensional pixel coordinate system that produces pixel perfect rendering when `z == 0` and the camera is in its default position over a target surface / window.

